### PR TITLE
Define gateway control port

### DIFF
--- a/files/root/exareme/etc/exareme/gateway.properties
+++ b/files/root/exareme/etc/exareme/gateway.properties
@@ -48,6 +48,7 @@ gateway.response.errors=errors
 # HTTP Server
 # -------------------------------------------------------------------------------- #
 gateway.port=9090
+gateway.controlPort=9091
 gateway.bufferSizeKB=16
 gateway.noDelay=true
 gateway.waitForTerminationSec=30


### PR DESCRIPTION
This control port is for internal use only (ie it is not necessary to be accessible outside of the container)